### PR TITLE
Implementação de inversão de controle/ injeção de dependências sob HttpClient.

### DIFF
--- a/lib/pages/loginpages.dart
+++ b/lib/pages/loginpages.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:controle_financeiro_pessoal/model/service.dart';
 import 'package:controle_financeiro_pessoal/services/apiService.dart';
 import 'package:controle_financeiro_pessoal/services/loginAPIService.dart';
@@ -194,8 +196,8 @@ class _LoginPageState extends State<LoginPage> {
                           }
                         
                           void _checkLoginCredentials(TextEditingController email, TextEditingController password) {
-                            
-                            LoginAPIService loginAPIService = LoginAPIService();
+                            HttpClient httpClient = new HttpClient();
+                            LoginAPIService loginAPIService = LoginAPIService(httpClient);
                             Service service = Service(loginAPIService);
                             // TO-DO: create login body accordingly.
                             //service.post(body);

--- a/lib/services/APIService.dart
+++ b/lib/services/APIService.dart
@@ -3,6 +3,6 @@ abstract class APIService {
   String uri;
   
   Future<String> post(Map body);
-  // TODO: implement post get, put and delete.
+  // TODO: implement get, put and delete.
 
 }

--- a/lib/services/clubAPIService.dart
+++ b/lib/services/clubAPIService.dart
@@ -9,19 +9,26 @@ class ClubAPIService implements APIService{
   String uri = "http://labs.believeit.com.br/projetos/tennis-app-api/api/club";
 
   @override
+  HttpClient httpClient;
+
+  ClubAPIService(this.httpClient);
+
+  @override
   Future<String> post(Map body) async {
     // Em português: só faz sentido se as APIs pedirem trativas diferentes para cada recurso. Isso ainda não está definido.
     // TODO: set or maintain CLUB body accordingly.
-    var httpClient = new HttpClient();
-    final request = await HttpClient().postUrl(Uri.parse(this.uri));
+    HttpClient httpClient = new HttpClient();
+    
+    final request = await this.httpClient.postUrl(Uri.parse(this.uri));
     request.headers.set('content-type', 'applicaton/json');
     request.add(utf8.encode(json.encode(body)));
     HttpClientResponse response = await request.close();
     // TODO: check response.statusCode.
     String reply = await response.transform(utf8.decoder).join();
-    httpClient.close();
+    this.httpClient.close();
     return reply;
 
   }
+
 
 }

--- a/lib/services/loginAPIService.dart
+++ b/lib/services/loginAPIService.dart
@@ -9,17 +9,21 @@ class LoginAPIService implements APIService{
   String uri = "http://labs.believeit.com.br/projetos/tennis-app-api/api/login"; // TODO: change it to the final version.
 
   @override
+  HttpClient httpClient;
+
+  LoginAPIService(this.httpClient);
+
+  @override
   Future<String> post(Map body) async {
-    // Em portugues: só faz sentido se as APIs pedirem trativas diferentes para cada recurso. Isso ainda não está definido.
+    // Em português: só faz sentido se as APIs pedirem trativas diferentes para cada recurso. Isso ainda não está definido.
     // TODO: set or maintain CLUB body accordingly.
-    var httpClient = new HttpClient();
-    final request = await HttpClient().postUrl(Uri.parse(this.uri));
+    final request = await this.httpClient.postUrl(Uri.parse(this.uri));
     request.headers.set('content-type', 'applicaton/json');
     request.add(utf8.encode(json.encode(body)));
     HttpClientResponse response = await request.close();
     // TODO: check response.statusCode.
     String reply = await response.transform(utf8.decoder).join();
-    httpClient.close();
+    this.httpClient.close();
     return reply;
 
   }

--- a/lib/services/userAPIService.dart
+++ b/lib/services/userAPIService.dart
@@ -9,17 +9,21 @@ class UserAPIService implements APIService{
   String uri = "http://labs.believeit.com.br/projetos/tennis-app-api/api/user";
 
   @override
+  HttpClient httpClient;
+
+  UserAPIService({this.httpClient});
+
+  @override
   Future<String> post(Map body) async {
     // Em português: só faz sentido se as APIs pedirem trativas diferentes para cada recurso. Isso ainda não está definido.
     // TODO: set or maintain USER body accordingly.
-    var httpClient = new HttpClient();
-    final request = await HttpClient().postUrl(Uri.parse(this.uri));
+    final request = await this.httpClient.postUrl(Uri.parse(this.uri));
     request.headers.set('content-type', 'applicaton/json');
     request.add(utf8.encode(json.encode(body)));
     HttpClientResponse response = await request.close();
     // TODO: check response.statusCode.
     String reply = await response.transform(utf8.decoder).join();
-    httpClient.close();
+    this.httpClient.close();
     return reply;
 
   }


### PR DESCRIPTION
     Através da necessidade do princípio de inversão de controle e de desacoplar em função da composição existente entre as classes das APIs e o HttpClient, fora implementada a injeção de dependências. Desta forma, coisas dos tipo criar mocks na escrita de nossos testes unitários (e outras) serão amplamente facilitadas em termos de reusabilidade, escalabilidade da aplicação, manutenabilidade, além de reduzir o acoplamento, como já citado.